### PR TITLE
Remove PREC field from login record in template file.

### DIFF
--- a/hamamatsuApp/Db/hamamatsu.template
+++ b/hamamatsuApp/Db/hamamatsu.template
@@ -175,7 +175,6 @@ record(longin, "$(P)$(R)HamaTriggerTimes_RBV")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR),$(TIMEOUT))HamaTriggerTimes")
-   field(PREC, "0")
    field(SCAN, "I/O Intr")
 }
 


### PR DESCRIPTION
To solve:

```
dbLoadRecords("/home/marcofilho/.conda/envs/orca/modules/adhamamatsudcam/1.0.0-alpha/db//hamamatsu.template","P=13HAMA1:,R=cam1:,PORT=HAMA1,ADDR=0,TIMEOUT=1")
longin Record "13HAMA1:cam1:HamaTriggerTimes_RBV" does not have a field "PREC"
    Did you mean "PROC"?  (Force Processing)
ERROR at or before ')' in file "/home/marcofilho/.conda/envs/orca/modules/adhamamatsudcam/1.0.0-alpha/db//hamamatsu.template" line 178
ERROR failed to load '/home/marcofilho/.conda/envs/orca/modules/adhamamatsudcam/1.0.0-alpha/db//hamamatsu.template'
```

I don't think longin has this field.
Another possible solution is to change the record type...