### PR TITLE
Fix function documention

### DIFF
--- a/iocs/hamamatsuIOC/iocBoot/iocHamamatsu/st_base.cmd
+++ b/iocs/hamamatsuIOC/iocBoot/iocHamamatsu/st_base.cmd
@@ -39,7 +39,7 @@ asynSetMinTimerPeriod(0.001)
 #epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES", "10000000")
 
 # Create a hamamatsu driver
-# hamamatsuConfig(const char *portName, int maxBuffers, int maxMemory, int priority, int stackSize)
+# hamamatsuConfig(const char *portName, int camIndex, int maxBuffers, int maxMemory, int priority, int stackSize)
 hamamatsuConfig("$(PORT)", 0, 0)
 # To have the rate calculation use a non-zero smoothing factor use the following line
 #dbLoadRecords("hamamatsu.template",     "P=$(PREFIX),R=cam1:,PORT=$(PORT),ADDR=0,TIMEOUT=1,RATE_SMOOTH=0.2")


### PR DESCRIPTION
According to source code:

```
static const iocshArg hamamatsuConfigArg0 = {"Port name", iocshArgString};
static const iocshArg hamamatsuConfigArg1 = {"camIndex", iocshArgInt};
static const iocshArg hamamatsuConfigArg2 = {"maxBuffers", iocshArgInt};
static const iocshArg hamamatsuConfigArg3 = {"maxMemory", iocshArgInt};
static const iocshArg hamamatsuConfigArg4 = {"priority", iocshArgInt};
static const iocshArg hamamatsuConfigArg5 = {"stackSize", iocshArgInt};
static const iocshArg * const hamamatsuConfigArgs[] =  {&hamamatsuConfigArg0,
                                                        &hamamatsuConfigArg1,
                                                        &hamamatsuConfigArg2,
                                                        &hamamatsuConfigArg3,
                                                        &hamamatsuConfigArg4,
                                                        &hamamatsuConfigArg5};
static const iocshFuncDef confighamamatsu = {"hamamatsuConfig", 6, hamamatsuConfigArgs};
```