### PR TITLE
Encapsulate read-checkerror and write-checkerror patterns. Remove debug prints and legacy comments.

### DIFF
--- a/hamamatsuApp/src/hamamatsu.h
+++ b/hamamatsuApp/src/hamamatsu.h
@@ -52,6 +52,11 @@ private:
     void get_image_information( HDCAM hdcam, int32& pixeltype, int32& width, int32& rowbytes, int32& height );
     void sample_access_image( HDCAM hdcam );
     void updateCoolerInfo(void);
+    static void getErrString(HDCAM handle, DCAMERR err, char* buf, unsigned int bufsize);
+    inline const bool checkErrAndPrint(const char* functionName, DCAMERR err, const char* paramName, ...);
+    inline const bool checkSetGet(int32 iProp, double* pValue, const char* functionName, const char* paramName);
+    inline const bool checkSet(int32 iProp, double pValue, const char* functionName, const char* paramName);
+    inline const bool checkGet(int32 iProp, double *pValue, const char* functionName, const char* paramName);
 
     /* Our data */
     epicsEventId startEventId_;


### PR DESCRIPTION
Encapsulate the pattern read/write-value-and-check-error in functions checkSet, checkGet and checkSetGet. This could maybe be improved with function pointers, but maybe would be overkill.
Now most error messages are sent via asynPrint with the correct log mask.

Also, turn prints that should be asynprint into that, delete prints that looked like debug prints and comments that looked just like legacy test code.

As far as I could test this changed no functionality. Acquisition with trigger mode internal still works as before. Trigger external seems to be weird, but was also weird before these modifications (probably will open separate issues about this later)