### PR TITLE
Implement ADTriggerMode, remove HamaTriggerMode

### DIFF
--- a/hamamatsuApp/Db/hamamatsu.template
+++ b/hamamatsuApp/Db/hamamatsu.template
@@ -42,6 +42,30 @@ record(mbbi, "$(P)$(R)ColorMode_RBV")
    field(EIST, "")
 }
 
+# TriggerMode has a different meaning in hamamatsu.
+# Not to be confused with TriggerSource.
+record(mbbo, "$(P)$(R)TriggerMode")
+{
+   field(DESC, "Trigger mode (see also TriggerSource)")
+   field(PINI, "YES")
+   field(DTYP, "asynInt32")
+   field(ZRVL, "1")
+   field(ZRST, "Normal")
+   field(ONVL, "6")
+   field(ONST, "Start")
+   field(VAL,  "0")
+   info(autosaveFields, "VAL")
+}
+
+record(mbbi, "$(P)$(R)TriggerMode_RBV")
+{
+   field(DTYP, "asynInt32")
+   field(ZRST, "Normal")
+   field(ZRVL, "0")
+   field(ONST, "Start")
+   field(ONVL, "1")
+   field(SCAN, "I/O Intr")
+}
 
 ###################################################################################
 #hamamatsu specific records
@@ -52,55 +76,36 @@ record(bo, "$(P)$(R)HamaRegionReset")
    info(asyn:READBACK, "1")
 }
 
-record(mbbo, "$(P)$(R)HamaTriggerSource")
+record(mbbo, "$(P)$(R)TriggerSource")
 {
    field(PINI, "YES")
+   field(DESC, "Trigger source")
    field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HamaTriggerSource")
+   field(ZRVL, "1")
    field(ZRST, "Internal")
-   field(ZRVL, "0")
+   field(ONVL, "2")
    field(ONST, "External")
-   field(ONVL, "1")
+   field(TWVL, "3")
    field(TWST, "Software")
-   field(TWVL, "2")
+   field(THVL, "4")
    field(VAL,  "0")
+   field(THST, "Master pulse")
+   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HamaTriggerSource")
    info(autosaveFields, "VAL")
 }
 
-record(mbbi, "$(P)$(R)HamaTriggerSource_RBV")
+record(mbbi, "$(P)$(R)TriggerSource_RBV")
 {
    field(DTYP, "asynInt32")
    field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HamaTriggerSource")
+   field(ZRVL, "1")
    field(ZRST, "Internal")
-   field(ZRVL, "0")
+   field(ONVL, "2")
    field(ONST, "External")
-   field(ONVL, "1")
+   field(TWVL, "3")
    field(TWST, "Software")
-   field(TWVL, "2")
-   field(SCAN, "I/O Intr")
-}
-
-record(mbbo, "$(P)$(R)HamaTriggerMode")
-{
-   field(PINI, "YES")
-   field(DTYP, "asynInt32")
-   field(OUT,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HamaTriggerMode")
-   field(ZRST, "Normal")
-   field(ZRVL, "0")
-   field(ONST, "Start")
-   field(ONVL, "1")
-   field(VAL,  "0")
-   info(autosaveFields, "VAL")
-}
-
-record(mbbi, "$(P)$(R)HamaTriggerMode_RBV")
-{
-   field(DTYP, "asynInt32")
-   field(INP,  "@asyn($(PORT),$(ADDR=0),$(TIMEOUT=1))HamaTriggerMode")
-   field(ZRST, "Normal")
-   field(ZRVL, "0")
-   field(ONST, "Start")
-   field(ONVL, "1")
+   field(THVL, "4")
+   field(THST, "Master pulse")
    field(SCAN, "I/O Intr")
 }
 

--- a/hamamatsuApp/src/hamamatsu.cpp
+++ b/hamamatsuApp/src/hamamatsu.cpp
@@ -813,41 +813,13 @@ asynStatus hamamatsu::writeInt32(asynUser *pasynUser, epicsInt32 value)
             driverName, functionName, tempResetVal, tempResetVal, tempMax, tempMax);
     }
     
-    else if (function == HamaTriggerSource) { 
-        //0: internal 
-        //1: external 
-        //2: software
-        // We could implement checkSet(DCAM_IDPROP_TRIGGERSOURCE, value-1 ), but that counts with 
-        // the premise that the API would never change...
+    else if (function == HamaTriggerSource) {
         callParamCallbacks();
-        if (value == 0) {
-            checkSet(DCAM_IDPROP_TRIGGERSOURCE, DCAMPROP_TRIGGERSOURCE__INTERNAL, functionName, "IDPROP:TRIGGERSOURCE");
-        }
-        else if (value == 1) {
-            checkSet(DCAM_IDPROP_TRIGGERSOURCE, DCAMPROP_TRIGGERSOURCE__EXTERNAL, functionName, "IDPROP:TRIGGERSOURCE");
-        }
-        else if (value == 2) {
-            checkSet(DCAM_IDPROP_TRIGGERSOURCE, DCAMPROP_TRIGGERSOURCE__SOFTWARE, functionName, "IDPROP:TRIGGERSOURCE");
-        } else {
-            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Invalid trigger source option. "
-                " Available options are 0 (internal), 1 (external) and 2 (software)\n",
-                driverName, functionName);
-        }
+        checkSet(DCAM_IDPROP_TRIGGERSOURCE, value, functionName, "IDPROP:TRIGGERSOURCE");
     }
 
-    else if (function == HamaTriggerMode) { 
-        //0:normal
-        //1:start
-        if (value == 0) {
-            checkSet(DCAM_IDPROP_TRIGGER_MODE, DCAMPROP_TRIGGER_MODE__NORMAL, functionName, "IDPROP:TRIGGER_MODE");
-        }
-        else if (value == 1) {
-            checkSet(DCAM_IDPROP_TRIGGER_MODE, DCAMPROP_TRIGGER_MODE__START, functionName, "IDPROP:TRIGGER_MODE");
-        } else {
-            asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, "%s:%s: Invalid trigger mode option. "
-                " Available options are 0 (normal) and 1 (start).\n",
-                driverName, functionName);
-        }
+    else if (function == ADTriggerMode) {
+        checkSet(DCAM_IDPROP_TRIGGER_MODE, value, functionName, "IDPROP:TRIGGER_MODE");
         callParamCallbacks();
     }
 
@@ -889,7 +861,7 @@ asynStatus hamamatsu::writeInt32(asynUser *pasynUser, epicsInt32 value)
     else if (function == HamaFireTrigger) {
         dcamcap_firetrigger( hdcam );
         int triggermode;
-        getIntegerParam(HamaTriggerMode, &triggermode);
+        getIntegerParam(ADTriggerMode, &triggermode);
         if (triggermode == 1) { //trigger mode = start
              setIntegerParam(HamaTriggerSource,0);// internal
         }
@@ -1137,7 +1109,6 @@ hamamatsu::hamamatsu(const char *portName, int camIndex, int maxBuffers, size_t 
     
     //Hamamatsu Trigger parameters
     createParam(HamaTriggerSourceString,      asynParamInt32,   &HamaTriggerSource);
-    createParam(HamaTriggerModeString,        asynParamInt32,   &HamaTriggerMode);
     createParam(HamaTriggerActiveString,      asynParamInt32,   &HamaTriggerActive);
     createParam(HamaTriggerPolarityString,    asynParamInt32,   &HamaTriggerPolarity);
     createParam(HamaFireTriggerString,        asynParamInt32,   &HamaFireTrigger);
@@ -1151,9 +1122,10 @@ hamamatsu::hamamatsu(const char *portName, int camIndex, int maxBuffers, size_t 
     createParam(HamaSystemAliveString,        asynParamInt32, &HamaSystemAlive);
 
     /* Set some default values for parameters */
+    status |= setIntegerParam(ADTriggerMode,0);
+
     status |= setIntegerParam(HamaRegionReset,0);
     status |= setIntegerParam(HamaTriggerSource,0);
-    status |= setIntegerParam(HamaTriggerMode,0);
     status |= setIntegerParam(HamaTriggerActive,0);
     status |= setIntegerParam(HamaTriggerPolarity,0);
     status |= setIntegerParam(HamaFireTrigger,0);

--- a/hamamatsuApp/src/hamamatsu.h
+++ b/hamamatsuApp/src/hamamatsu.h
@@ -35,7 +35,6 @@ protected:
     int HamaRegionReset;
     #define FIRST_HAMA_DETECTOR_PARAM HamaRegionReset
     int HamaTriggerSource;
-    int HamaTriggerMode;
     int HamaTriggerActive;
     int HamaTriggerPolarity;
     int HamaFireTrigger;
@@ -68,7 +67,6 @@ private:
 
 #define HamaRegionResetString         "HamaRegionReset"
 #define HamaTriggerSourceString       "HamaTriggerSource"
-#define HamaTriggerModeString         "HamaTriggerMode"
 #define HamaTriggerActiveString       "HamaTriggerActive"
 #define HamaTriggerPolarityString     "HamaTriggerPolarity"
 #define HamaFireTriggerString         "HamaFireTrigger"

--- a/hamamatsuApp/src/hamamatsu.h
+++ b/hamamatsuApp/src/hamamatsu.h
@@ -52,6 +52,11 @@ private:
     void get_image_information( HDCAM hdcam, int32& pixeltype, int32& width, int32& rowbytes, int32& height );
     void sample_access_image( HDCAM hdcam );
     void updateCoolerInfo(void);
+    static void getErrString(HDCAM handle, DCAMERR err, char* buf, unsigned int bufsize);
+    inline const bool checkErrAndPrint(const char* functionName, DCAMERR err, const char* paramName, ...);
+    inline const bool checkSetGet(int32 iProp, double* pValue, const char* functionName, const char* paramName);
+    inline const bool checkSet(int32 iProp, double pValue, const char* functionName, const char* paramName);
+    inline const bool checkGet(int32 iProp, double *pValue, const char* functionName, const char* paramName);
 
     /* Our data */
     epicsEventId startEventId_;


### PR DESCRIPTION
[This issue](https://github.com/areaDetector/ADHamamatsuDCAM/issues/12) was generated by a confusion: there was a working implemented TriggerMode PV, but it was called HamaTriggerMode. ADBase TriggerMode was simply not implemented.

To avoid this confusion I remove HamaTriggerMode. A good thing to pay attention is that for this particular module, TriggerMode and TriggerSource are two separate things. TriggerSource is just Internal, External and Software definitions. TriggerMode is about how will the trigger define the camera exposure time and other acquisition properties.

This must be merged only after [this PR](https://github.com/areaDetector/ADHamamatsuDCAM/pull/10) or it should be rebased. 